### PR TITLE
デフォルトで通知するお知らせの日数を2日分から1日分に変更

### DIFF
--- a/twins-notification.config.yaml
+++ b/twins-notification.config.yaml
@@ -10,7 +10,7 @@ notify_by:
 #    1 = 昨日と今日掲示されたお知らせを通知
 #    0 = 今日掲示されたお知らせを通知
 #    -1 = すべてのお知らせを通知
-notify_since_days: 1
+notify_since_days: 0
 
 # 無視するお知らせの種類を指定します。
 ignore_genres:


### PR DESCRIPTION
**What**
デフォルトで通知するお知らせの日数を2日分から1日分に変更します。

**Why**
2日1回よりも1日1回の通知を行うほうが普通だからです。